### PR TITLE
Added support for named credentials, added more methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apex Callouts
 A lightweight Apex library for making HTTP callouts <br />
 <a href="https://githubsfdeploy.herokuapp.com" target="_blank">
-  <img alt="Deploy to Salesforce" src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/deploy.png">
+    <img alt="Deploy to Salesforce" src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/deploy.png">
 </a>
 
 ## Using Callout Constructors
@@ -38,3 +38,13 @@ For all 3 scenarios, the header 'Content-Type' is automatically set based on the
 
 ## Error Handling
 When the callout is made, any status code >= 400 automatically throws an instance of Callout.HttpResponseException exception
+
+## Example Usage
+GET request with headers & parameters, using chained method calls
+```
+HttpResponse myCalloutResponse = new Callout('https://api.example.com/fake/1')
+    .addHeader('myHeader', 'myHeaderValue')
+    .addParameter('myFirstParameter', 'someValue')
+    .addParameter('mySecondParameter', 'anotherVomeValue')
+    .get();
+```

--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@ A lightweight Apex library for making HTTP callouts
   <img alt="Deploy to Salesforce" src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/deploy.png">
 </a>
 
-## Using Callouts.cls - 2 constructors
+## Using Callout Constructors
 - **Callout(String endpoint)** - used when you have a full URL for the endpoint and you are using [remote site settings](https://help.salesforce.com/articleView?id=configuring_remoteproxy.htm&type=5)
 - **Callout(String namedCredential, String endpointPath)** - used with [named credentials](https://help.salesforce.com/articleView?id=named_credentials_about.htm&type=5). To use this, the named credential's endpoint should be just the base URL of the API. The specific endpoint resource to call is then provided via the endpointPath parameter.
 
-# Building Your Request
+# Building Your Callout Request
 Once you have instantiated an instance of Callout, you can setup additional options for the callout, like adding headers & parameters. Each builder method returns the current instance of Callout, allowing you to chain the builder methods.
 * Callout addHeader(String key, String value)
 * Callout addHeaders(Map<String, String> headers)
 * Callout addParameter(String key, String value)
 * Callout addParameters(Map<String, String> parameters)
-* Callout setCompressed() - enable or disable compression for the request
+* Callout setCompressed()
 * Callout setCompressed(Boolean compress)
 * Callout setTimeout(Integer timeoutMs)
 
-# Making the callout
+# Making Your Callout Request
 Once you have instantiated an instance of Callout and setup the headers & parameters (if needed), you can call any of the HTTP verb methods - each method returns an instance of HttpResponse.
 * HttpResponse del()
 * HttpResponse get()
@@ -28,7 +28,7 @@ Once you have instantiated an instance of Callout and setup the headers & parame
 * HttpResponse put(Object requestBody)
 * HttpResponse trace()
 
-## PATCH, POST & PUT methods
+# PATCH, POST & PUT methods
 Patch, post & put methods accept an Object as a parameter, with 3 main types supported
 * **Blob**:  Callout automatically uses setBodyAsBlob(yourBlob)
 * **Dom.Document**:  Callout automatically uses setBodyDocument(yourDocument)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Apex Callouts
 A lightweight Apex library for making HTTP callouts
-[![Deploy to Salesforce](https://img.shields.io/badge/salesforce-deploy-blue.svg)](https://githubsfdeploy.herokuapp.com)
+<a href="https://githubsfdeploy.herokuapp.com" target="_blank">
+  <img alt="Deploy to Salesforce" src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/deploy.png">
+</a>
 
 ## Using Callouts.cls - 2 constructors
 - **Callout(String endpoint)** - used when you have a full URL for the endpoint and you are using [remote site settings](https://help.salesforce.com/articleView?id=configuring_remoteproxy.htm&type=5)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ GET request with headers & parameters, using chained method calls & named creden
 HttpResponse myCalloutResponse = new Callout('myExampleNamedCredential', '/fakeResource')
     .addHeader('myHeader', 'myHeaderValue')
     .addParameter('myFirstParameter', 'someValue')
-    .addParameter('mySecondParameter', 'anotherVomeValue')
+    .addParameter('mySecondParameter', 'anotherValue')
     .get();
 ```
 
@@ -54,6 +54,6 @@ GET request with headers & parameters, using chained method calls & a full URL (
 HttpResponse myCalloutResponse = new Callout('https://api.example.com/fakeResource')
     .addHeader('myHeader', 'myHeaderValue')
     .addParameter('myFirstParameter', 'someValue')
-    .addParameter('mySecondParameter', 'anotherVomeValue')
+    .addParameter('mySecondParameter', 'anotherValue')
     .get();
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A lightweight Apex library for making HTTP callouts <br />
 - **Callout(String endpoint)** - used when you have a full URL for the endpoint and you are using [remote site settings](https://help.salesforce.com/articleView?id=configuring_remoteproxy.htm&type=5)
 - **Callout(String namedCredential, String endpointPath)** - used with [named credentials](https://help.salesforce.com/articleView?id=named_credentials_about.htm&type=5). To use this, the named credential's endpoint should be just the base URL of the API. The specific endpoint resource to call is then provided via the endpointPath parameter.
 
-# Building Your Callout Request
+## Building Your Callout Request
 Once you have instantiated an instance of Callout, you can setup additional options for the callout, like adding headers & parameters. Each builder method returns the current instance of Callout, allowing you to chain the builder methods.
 * Callout addHeader(String key, String value)
 * Callout addHeaders(Map<String, String> headers)
@@ -18,7 +18,7 @@ Once you have instantiated an instance of Callout, you can setup additional opti
 * Callout setCompressed(Boolean compress)
 * Callout setTimeout(Integer timeoutMs)
 
-# Making Your Callout Request
+## Making Your Callout Request
 Once you have instantiated an instance of Callout and setup the headers & parameters (if needed), you can call any of the HTTP verb methods - each method returns an instance of HttpResponse.
 * HttpResponse del() - 'delete' is a reserved word in Apex, so the method name has been abbreviated
 * HttpResponse get()
@@ -28,7 +28,7 @@ Once you have instantiated an instance of Callout and setup the headers & parame
 * HttpResponse put(Object requestBody)
 * HttpResponse trace()
 
-# PATCH, POST & PUT methods
+## PATCH, POST & PUT methods
 Patch, post & put methods accept an Object as a parameter, with 3 main types supported
 * **Blob**:  Callout automatically uses setBodyAsBlob(yourBlob)
 * **Dom.Document**:  Callout automatically uses setBodyDocument(yourDocument)
@@ -36,5 +36,5 @@ Patch, post & put methods accept an Object as a parameter, with 3 main types sup
 
 For all 3 scenarios, the header 'Content-Type' is automatically set based on the request body if the header has not already been set
 
-# Error Handling
+## Error Handling
 When the callout is made, any status code >= 400 automatically throws an instance of Callout.HttpResponseException exception

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Apex Callouts
-A lightweight Apex library for making HTTP callouts
+A lightweight Apex library for making HTTP callouts <br />
 <a href="https://githubsfdeploy.herokuapp.com" target="_blank">
   <img alt="Deploy to Salesforce" src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/deploy.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Once you have instantiated an instance of Callout, you can setup additional opti
 
 # Making Your Callout Request
 Once you have instantiated an instance of Callout and setup the headers & parameters (if needed), you can call any of the HTTP verb methods - each method returns an instance of HttpResponse.
-* HttpResponse del()
+* HttpResponse del() - 'delete' is a reserved word in Apex, so the method name has been abbreviated
 * HttpResponse get()
 * HttpResponse head()
 * HttpResponse patch(Object requestBody)

--- a/README.md
+++ b/README.md
@@ -40,9 +40,18 @@ For all 3 scenarios, the header 'Content-Type' is automatically set based on the
 When the callout is made, any status code >= 400 automatically throws an instance of Callout.HttpResponseException exception
 
 ## Example Usage
-GET request with headers & parameters, using chained method calls
+GET request with headers & parameters, using chained method calls & named credentials
 ```
-HttpResponse myCalloutResponse = new Callout('https://api.example.com/fake/1')
+HttpResponse myCalloutResponse = new Callout('myExampleNamedCredential', '/fakeResource')
+    .addHeader('myHeader', 'myHeaderValue')
+    .addParameter('myFirstParameter', 'someValue')
+    .addParameter('mySecondParameter', 'anotherVomeValue')
+    .get();
+```
+
+GET request with headers & parameters, using chained method calls & a full URL (remote site settings)
+```
+HttpResponse myCalloutResponse = new Callout('https://api.example.com/fakeResource')
     .addHeader('myHeader', 'myHeaderValue')
     .addParameter('myFirstParameter', 'someValue')
     .addParameter('mySecondParameter', 'anotherVomeValue')

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Apex Callouts
+A lightweight Apex library for making HTTP callouts
+[![Deploy to Salesforce](https://img.shields.io/badge/salesforce-deploy-blue.svg)](https://githubsfdeploy.herokuapp.com)
+
+## Using Callouts.cls - 2 constructors
+- **Callout(String endpoint)** - used when you have a full URL for the endpoint and you are using [remote site settings](https://help.salesforce.com/articleView?id=configuring_remoteproxy.htm&type=5)
+- **Callout(String namedCredential, String endpointPath)** - used with [named credentials](https://help.salesforce.com/articleView?id=named_credentials_about.htm&type=5). To use this, the named credential's endpoint should be just the base URL of the API. The specific endpoint resource to call is then provided via the endpointPath parameter.
+
+# Building Your Request
+Once you have instantiated an instance of Callout, you can setup additional options for the callout, like adding headers & parameters. Each builder method returns the current instance of Callout, allowing you to chain the builder methods.
+* Callout addHeader(String key, String value)
+* Callout addHeaders(Map<String, String> headers)
+* Callout addParameter(String key, String value)
+* Callout addParameters(Map<String, String> parameters)
+* Callout setCompressed() - enable or disable compression for the request
+* Callout setCompressed(Boolean compress)
+* Callout setTimeout(Integer timeoutMs)
+
+# Making the callout
+Once you have instantiated an instance of Callout and setup the headers & parameters (if needed), you can call any of the HTTP verb methods - each method returns an instance of HttpResponse.
+* HttpResponse del()
+* HttpResponse get()
+* HttpResponse head()
+* HttpResponse patch(Object requestBody)
+* HttpResponse post(Object requestBody)
+* HttpResponse put(Object requestBody)
+* HttpResponse trace()
+
+## PATCH, POST & PUT methods
+Patch, post & put methods accept an Object as a parameter, with 3 main types supported
+* **Blob**:  Callout automatically uses setBodyAsBlob(yourBlob)
+* **Dom.Document**:  Callout automatically uses setBodyDocument(yourDocument)
+* **Serializable Object**: Any other object types will be serialized and sent as JSON
+
+For all 3 scenarios, the header 'Content-Type' is automatically set based on the request body if the header has not already been set
+
+# Error Handling
+When the callout is made, any status code >= 400 automatically throws an instance of Callout.HttpResponseException exception

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -15,9 +15,6 @@ public class Callout {
         this.headers    = new Map<String, String>();
         this.parameters = new Map<String, String>();
         this.request    = new HttpRequest();
-
-        // Set default values - these can be overridden
-        this.addHeader('Content-Type', 'application/json');
     }
 
     public Callout addHeader(String key, String value) {
@@ -112,9 +109,21 @@ public class Callout {
     private void setRequestBody(Object requestBody) {
         if(requestBody == null) return;
 
-        if(requestBody instanceOf Blob) this.request.setBodyAsBlob((Blob)requestBody);
-        else if(requestBody instanceOf Dom.Document) this.request.setBodyDocument((Dom.Document)requestBody);
-        else this.request.setBody(JSON.serialize(requestBody));
+        // Determine if the content type has already been set
+        // If it's null, then it will be automatically set based on the request body
+        Boolean contentTypeNotSet = this.headers.get('Content-Type') == null;
+
+        if(requestBody instanceOf Blob) {
+            this.request.setBodyAsBlob((Blob)requestBody);
+            if(contentTypeNotSet) this.addHeader('Content-Type', 'multipart/form-data; charset=utf-8');
+        }
+        else if(requestBody instanceOf Dom.Document) {
+            this.request.setBodyDocument((Dom.Document)requestBody);
+            if(contentTypeNotSet) this.addHeader('Content-Type', 'text/xml; charset=utf-8');
+        } else {
+            this.request.setBody(JSON.serialize(requestBody));
+            if(contentTypeNotSet) this.addHeader('Content-Type', 'application/json; charset=utf-8');
+        }
     }
 
     private void validateResponse(Httpresponse response) {

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -73,9 +73,15 @@ public class Callout {
     }
 
     private HttpResponse executeCallout(String httpVerb, Object requestBody) {
-        // Set the method & request body
+        // Set the method
         this.request.setMethod(httpVerb);
-        if(requestBody != null) this.request.setBody(JSON.serialize(requestBody));
+
+        // Set the request body based on the data provided
+        if(requestBody != null) {
+            if(requestBody instanceOf Blob) this.request.setBodyAsBlob((Blob)requestBody);
+            else if(requestBody instanceOf Dom.Document) this.request.setBodyDocument((Dom.Document)requestBody);
+            else this.request.setBody(JSON.serialize(requestBody));
+        }
 
         // Set the headers
         for(String headerKey : this.headers.keySet()) {

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -106,7 +106,11 @@ public class Callout {
     private void validateResponse(Httpresponse response) {
         Integer statusCode = response.getStatusCode();
         if(statusCode >= 400 && statusCode <= 599) {
-            String errorMessage = 'Callout failed for ' + this.endpoint + '. Received request status code '
+            // Get the endpoint without any parameters so that no sensitive parameters are exposed to users
+            Integer endpointParametersStart = this.endpoint.indexOf('?');
+            String endpointWithoutParameters = endpointParametersStart > 0 ? this.endpoint.left(endpointParametersStart) : this.endpoint;
+
+            String errorMessage = 'Callout failed for ' + endpointWithoutParameters + '. Received request status code '
                 + statusCode + ', status message: ' + response.getStatus();
             throw new HttpResponseException(errorMessage);
         }

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -102,21 +102,20 @@ public class Callout {
         // Set the parameters & endpoint
         String parameterString = '';
         for(String parameterKey : this.parameters.keySet()) {
-            String prefix = String.isEmpty(parameterString) && !this.endpoint.contains('?') ? '?' : '&';
-            parameterString += prefix + parameterKey + '=' + this.parameters.get(parameterKey);
+            String paremeterDelimiter = String.isEmpty(parameterString) && !this.endpoint.contains('?') ? '?' : '&';
+            parameterString += paremeterDelimiter + parameterKey + '=' + this.parameters.get(parameterKey);
         }
         this.request.setEndpoint(this.endpoint + parameterString);
 
         // Return the response
-        Http http = new Http();
-        HttpResponse response = http.send(this.request);
+        HttpResponse response = new Http().send(this.request);
         this.validateResponse(response);
         return response;
     }
 
     private void validateResponse(Httpresponse response) {
         Integer statusCode = response.getStatusCode();
-        if(statusCode >= 400 && statusCode <= 599) {
+        if(statusCode >= 400) {
             // Get the endpoint without any parameters so that no sensitive parameters are exposed to users
             Integer endpointParametersStart = this.endpoint.indexOf('?');
             String endpointWithoutParameters = endpointParametersStart > 0 ? this.endpoint.left(endpointParametersStart) : this.endpoint;

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -1,5 +1,6 @@
 public class Callout {
 
+    private Boolean disableResponseValidation;
     private String endpoint;
     private Map<String, String> headers;
     private Map<String, String> parameters;
@@ -12,9 +13,10 @@ public class Callout {
     public Callout(String endpoint) {
         this.endpoint = endpoint;
 
-        this.headers    = new Map<String, String>();
-        this.parameters = new Map<String, String>();
-        this.request    = new HttpRequest();
+        this.disableResponseValidation = false;
+        this.headers                   = new Map<String, String>();
+        this.parameters                = new Map<String, String>();
+        this.request                   = new HttpRequest();
 
         // Set JSON as the default content-type - it can be overridden
         this.addHeader('Content-Type', 'application/json');
@@ -41,6 +43,11 @@ public class Callout {
 
     public Callout setTimeout(Integer timeoutMs) {
         this.request.setTimeout(timeoutMs);
+        return this;
+    }
+
+    public Callout disableResponseValidation(Boolean disableResponseValidation) {
+        this.disableResponseValidation = disableResponseValidation;
         return this;
     }
 
@@ -94,7 +101,20 @@ public class Callout {
         // Return the response
         Http http = new Http();
         HttpResponse response = http.send(this.request);
+        this.validateResponse(response);
         return response;
     }
+
+    private void validateResponse(Httpresponse response) {
+        // If validation is disabled, don't do anything
+        if(this.disableResponseValidation) return;
+
+        Integer statusCode = response.getStatusCode();
+        if(statusCode >= 400 && statusCode <= 599) {
+            throw new HttpResponseException('Received request status code ' + statusCode + ', status message: ' + response.getStatus());
+        }
+    }
+
+    private class HttpResponseException extends Exception {}
 
 }

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -15,6 +15,9 @@ public class Callout {
         this.headers    = new Map<String, String>();
         this.parameters = new Map<String, String>();
         this.request    = new HttpRequest();
+
+        // Set JSON as the default content-type - it can be overridden
+        this.addHeader('Content-Type', 'application/json');
     }
 
     public Callout addHeader(String key, String value) {

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -64,15 +64,15 @@ public class Callout {
         return this.executeCallout('HEAD', null);
     }
 
-    public HttpResponse patch(String requestBody) {
+    public HttpResponse patch(Object requestBody) {
         return this.executeCallout('PATCH', requestBody);
     }
 
-    public HttpResponse post(String requestBody) {
+    public HttpResponse post(Object requestBody) {
         return this.executeCallout('POST', requestBody);
     }
 
-    public HttpResponse put(String requestBody) {
+    public HttpResponse put(Object requestBody) {
         return this.executeCallout('PUT', requestBody);
     }
 
@@ -80,10 +80,10 @@ public class Callout {
         return this.executeCallout('TRACE', null);
     }
 
-    private HttpResponse executeCallout(String httpVerb, String requestBody) {
+    private HttpResponse executeCallout(String httpVerb, Object requestBody) {
         // Set the method & request body
         this.request.setMethod(httpVerb);
-        if(requestBody != null) this.request.setBody(requestBody);
+        if(requestBody != null) this.request.setBody(JSON.serialize(requestBody));
 
         // Set the headers
         for(String headerKey : this.headers.keySet()) {

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -93,7 +93,7 @@ public class Callout {
         // Set the parameters & endpoint
         String parameterString = '';
         for(String parameterKey : this.parameters.keySet()) {
-            String prefix = String.isEmpty(parameterString) ? '?' : '&';
+            String prefix = String.isEmpty(parameterString) && !this.endpoint.contains('?') ? '?' : '&';
             parameterString += prefix + parameterKey + '=' + this.parameters.get(parameterKey);
         }
         this.request.setEndpoint(this.endpoint + parameterString);

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -1,4 +1,5 @@
 public class Callout {
+
     private String endpoint;
     private Map<String, String> headers;
     private Map<String, String> parameters;

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -1,6 +1,4 @@
 public class Callout {
-
-    private Boolean disableResponseValidation;
     private String endpoint;
     private Map<String, String> headers;
     private Map<String, String> parameters;
@@ -18,7 +16,6 @@ public class Callout {
         this.request    = new HttpRequest();
 
         // Set some default values - these can be overridden
-        this.disableResponseValidation = false;
         this.addHeader('Content-Type', 'application/json');
     }
 
@@ -43,11 +40,6 @@ public class Callout {
 
     public Callout setTimeout(Integer timeoutMs) {
         this.request.setTimeout(timeoutMs);
-        return this;
-    }
-
-    public Callout disableResponseValidation(Boolean disableResponseValidation) {
-        this.disableResponseValidation = disableResponseValidation;
         return this;
     }
 
@@ -106,9 +98,6 @@ public class Callout {
     }
 
     private void validateResponse(Httpresponse response) {
-        // If validation is disabled, don't do anything
-        if(this.disableResponseValidation) return;
-
         Integer statusCode = response.getStatusCode();
         if(statusCode >= 400 && statusCode <= 599) {
             throw new HttpResponseException('Received request status code ' + statusCode + ', status message: ' + response.getStatus());

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -61,8 +61,8 @@ public class Callout {
     }
 
     private HttpResponse executeCallout(String httpVerb, String requestBody) {
+        // Set the method & request body
         this.request.setMethod(httpVerb);
-
         if(requestBody != null) this.request.setBody(requestBody);
 
         // Set the headers
@@ -70,14 +70,12 @@ public class Callout {
             this.request.setHeader(headerKey, this.headers.get(headerKey));
         }
 
-        // Set the parameters
+        // Set the parameters & endpoint
         String parameterString = '';
         for(String parameterKey : this.parameters.keySet()) {
             String prefix = String.isEmpty(parameterString) ? '?' : '&';
             parameterString += prefix + parameterKey + '=' + this.parameters.get(parameterKey);
         }
-
-         // Set the endpoint
         this.request.setEndpoint(this.endpoint + parameterString);
 
         // Return the response

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -16,7 +16,7 @@ public class Callout {
         this.parameters = new Map<String, String>();
         this.request    = new HttpRequest();
 
-        // Set some default values - these can be overridden
+        // Set default values - these can be overridden
         this.addHeader('Content-Type', 'application/json');
     }
 
@@ -84,33 +84,37 @@ public class Callout {
     }
 
     private HttpResponse executeCallout(String httpVerb, Object requestBody) {
-        // Set the method
         this.request.setMethod(httpVerb);
+        this.setHeaders();
+        this.setEndpointAndParameters();
+        this.setRequestBody(requestBody);
 
-        // Set the request body based on the data provided
-        if(requestBody != null) {
-            if(requestBody instanceOf Blob) this.request.setBodyAsBlob((Blob)requestBody);
-            else if(requestBody instanceOf Dom.Document) this.request.setBodyDocument((Dom.Document)requestBody);
-            else this.request.setBody(JSON.serialize(requestBody));
-        }
+        HttpResponse response = new Http().send(this.request);
+        this.validateResponse(response);
+        return response;
+    }
 
-        // Set the headers
+    private void setHeaders() {
         for(String headerKey : this.headers.keySet()) {
             this.request.setHeader(headerKey, this.headers.get(headerKey));
         }
+    }
 
-        // Set the parameters & endpoint
+    private void setEndpointAndParameters() {
         String parameterString = '';
         for(String parameterKey : this.parameters.keySet()) {
             String paremeterDelimiter = String.isEmpty(parameterString) && !this.endpoint.contains('?') ? '?' : '&';
             parameterString += paremeterDelimiter + parameterKey + '=' + this.parameters.get(parameterKey);
         }
         this.request.setEndpoint(this.endpoint + parameterString);
+    }
 
-        // Return the response
-        HttpResponse response = new Http().send(this.request);
-        this.validateResponse(response);
-        return response;
+    private void setRequestBody(Object requestBody) {
+        if(requestBody == null) return;
+
+        if(requestBody instanceOf Blob) this.request.setBodyAsBlob((Blob)requestBody);
+        else if(requestBody instanceOf Dom.Document) this.request.setBodyDocument((Dom.Document)requestBody);
+        else this.request.setBody(JSON.serialize(requestBody));
     }
 
     private void validateResponse(Httpresponse response) {

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -25,8 +25,18 @@ public class Callout {
         return this;
     }
 
+    public Callout addHeaders(Map<String, String> headers) {
+        this.headers.putAll(headers);
+        return this;
+    }
+
     public Callout addParameter(String key, String value) {
         this.parameters.put(key, value);
+        return this;
+    }
+
+    public Callout addParameters(Map<String, String> parameters) {
+        this.parameters.putAll(parameters);
         return this;
     }
 

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -5,6 +5,10 @@ public class Callout {
     private Map<String, String> parameters;
     private HttpRequest request;
 
+    public Callout(String namedCredential, String endpointPath) {
+        this('callout:' + namedCredential + endpointPath);
+    }
+
     public Callout(String endpoint) {
         this.endpoint = endpoint;
 

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -30,6 +30,15 @@ public class Callout {
         return this;
     }
 
+    public Callout setCompressed() {
+        return this.setCompressed(true);
+    }
+
+    public Callout setCompressed(Boolean compress) {
+        this.request.setCompressed(compress);
+        return this;
+    }
+
     public Callout setTimeout(Integer timeoutMs) {
         this.request.setTimeout(timeoutMs);
         return this;

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -33,6 +33,7 @@ public class Callout {
     }
 
     public HttpResponse del() {
+        // 'DELETE' is a reserved word in Apex, so method name has been abbreviated
         return this.executeCallout('DELETE', null);
     }
 

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -13,12 +13,12 @@ public class Callout {
     public Callout(String endpoint) {
         this.endpoint = endpoint;
 
-        this.disableResponseValidation = false;
-        this.headers                   = new Map<String, String>();
-        this.parameters                = new Map<String, String>();
-        this.request                   = new HttpRequest();
+        this.headers    = new Map<String, String>();
+        this.parameters = new Map<String, String>();
+        this.request    = new HttpRequest();
 
-        // Set JSON as the default content-type - it can be overridden
+        // Set some default values - these can be overridden
+        this.disableResponseValidation = false;
         this.addHeader('Content-Type', 'application/json');
     }
 

--- a/src/classes/Callout.cls
+++ b/src/classes/Callout.cls
@@ -100,7 +100,9 @@ public class Callout {
     private void validateResponse(Httpresponse response) {
         Integer statusCode = response.getStatusCode();
         if(statusCode >= 400 && statusCode <= 599) {
-            throw new HttpResponseException('Received request status code ' + statusCode + ', status message: ' + response.getStatus());
+            String errorMessage = 'Callout failed for ' + this.endpoint + '. Received request status code '
+                + statusCode + ', status message: ' + response.getStatus();
+            throw new HttpResponseException(errorMessage);
         }
     }
 


### PR DESCRIPTION
# Callout now has 2 constructors
- **Callout(String endpoint)** - used when you have a full URL for the endpoint and you are using [remote site settings](https://help.salesforce.com/articleView?id=configuring_remoteproxy.htm&type=5)
- **Callout(String namedCredential, String endpointPath)** - used with [named credentials](https://help.salesforce.com/articleView?id=named_credentials_about.htm&type=5). To use this, the named credential's endpoint should be just the base URL of the API. The specific endpoint resource to call is then provided via the endpointPath parameter

# Error Handling
When the callout is made, any status code >= 400 now automatically throws an exception

# Patch, post & put method
Patch, post & put methods now take an Object as a parameter, instead of a String. This gives 2 benefits
* This prevents the need to always serialize the object first
* Blobs and Dom.Documents can now be used - the methods setBodyAsBlob & setBodyDocument are automatically used to set the callout request body. The header 'Content-Type' is set automatically based on the request body if the header has not already been set

# New Public Methods
- **setCompressed() & setCompressed(Boolean compress)** - enable or disable compression for the request
- **addHeaders(Map<String, String> headers)** - add a map of headers. This can be used in conjunction with addHeader(String key, String value)
- **addParemeters(Map<String, String> headers)** - add a map of parameters. This can be used in conjunction with addParameter(String key, String value)
